### PR TITLE
Prevent N queries on deploy

### DIFF
--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -165,7 +165,7 @@ class App < ActiveRecord::Base
   protected
 
     def store_cached_attributes_on_problems
-      problems.each(&:cache_app_attributes)
+      problems.update_all(:app_name => name)
     end
 
     def generate_api_key

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -38,7 +38,7 @@ class Deploy < ActiveRecord::Base
     end
 
     def store_cached_attributes_on_problems
-      Problem.where(:app_id => app.id).each(&:cache_app_attributes)
+      app.problems.in_env(environment).update_all(:last_deploy_at => created_at.utc)
     end
 end
 


### PR DESCRIPTION
Currently, deploying an app causes errbit to update all outstanding Problems in N queries, where N is the number of open Problems on that App; this PR reduces this to always require a single query. cc @ggilder @robolson
