### PR TITLE
Fixes issue with updating app.unresolved_problems_count

### DIFF
--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -16,7 +16,7 @@ class Notice < ActiveRecord::Base
   belongs_to :err
   belongs_to :backtrace
 
-  after_create :cache_attributes_on_problem, :unresolve_problem
+  after_create :unresolve_problem, :cache_attributes_on_problem
   before_save :sanitize
   before_destroy :decrease_counter_cache, :remove_cached_attributes_from_problem
   after_initialize :default_values
@@ -138,7 +138,7 @@ class Notice < ActiveRecord::Base
   end
 
   def unresolve_problem
-    problem.update_attributes!(:resolved => false, :resolved_at => nil, :notices_count => 1) if problem.resolved?
+    problem.update_attributes!(:resolved => false, :resolved_at => nil, :notices_count => 0) if problem.resolved?
   end
 
   def cache_attributes_on_problem

--- a/spec/models/problem_spec.rb
+++ b/spec/models/problem_spec.rb
@@ -311,5 +311,36 @@ describe Problem do
       }).to({})
     end
   end
+
+  context "app unresolved_problems_count cache" do
+    before do
+      @app = Fabricate(:app)
+      @problem = Fabricate(:problem, :app => @app)
+      @err = Fabricate(:err, :problem => @problem)
+      notice = Fabricate(:notice, :err => @err)
+    end
+
+    it "setting count to 1 when adding first problem" do
+      expect(@app.reload.unresolved_problems_count).to eq 1
+    end
+
+    it "setting count to 0 when all problems are resolved" do
+      @problem.resolve!
+      expect(@app.reload.unresolved_problems_count).to eq 0
+    end
+
+    it "increasing count after adding notice to existing error for resolved problem" do
+      @problem.resolve!
+      Fabricate(:notice, :err => @err)
+      expect(@app.reload.unresolved_problems_count).to eq 1
+    end
+
+    it "increasing count after adding new error to resolved problem" do
+      @problem.resolve!
+      err = Fabricate(:err, :problem => @problem)
+      Fabricate(:notice, :err => err)
+      expect(@app.reload.unresolved_problems_count).to eq 1
+    end
+  end
 end
 


### PR DESCRIPTION
App#unresolved_problems_count was not correctly updated in some situations
because of wrong after_create callbacks order in Notice. counter_culture runs
only once per transaction therefore it updated unresolved_problems_count
before Problem was unresolved resulting in wrong unresolved_problems_count
